### PR TITLE
add opam file

### DIFF
--- a/efftester.opam
+++ b/efftester.opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+
+synopsis: "Effect-Driven Compiler Tester for OCaml"
+
+version: "dev"
+license: "BSD-2-Clause"
+homepage: "https://github.com/gasche/efftester"
+bug-reports: "https://github.com/gasche/efftester/issues"
+
+authors: [
+  "Patrick Kasting"
+  "Mathias Nygaard Justesen"
+  "Jan Midtgaard"
+]
+maintainer: [
+  "Gabriel Scherer <gabriel.scherer@gmail.com>"
+  "Ulugbek Abdullaev <ulugbekna@gmail.com>"
+]
+dev-repo: "git+https://github.com/gasche/efftester.git"
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "qcheck" {>= "0.5.2"}
+  # FIXME: uncomment dune when set up
+  # "dune" {build}
+]
+depopts: [
+  "ocamlformat" {>= "0.9"}
+]
+
+conflicts: [
+  "ocamlformat" {< "0.9"}
+]
+
+build: [
+    [make "eff"]
+  # ["dune" "build" "-p" name "-j" jobs]
+]
+
+description: ""

--- a/efftester.opam
+++ b/efftester.opam
@@ -13,6 +13,7 @@ authors: [
   "Jan Midtgaard"
 ]
 maintainer: [
+  "Jan Midtgaard <mail@janmidtgaard.dk>"
   "Gabriel Scherer <gabriel.scherer@gmail.com>"
   "Ulugbek Abdullaev <ulugbekna@gmail.com>"
 ]
@@ -21,15 +22,9 @@ dev-repo: "git+https://github.com/gasche/efftester.git"
 depends: [
   "ocaml" {>= "4.04.0"}
   "qcheck" {>= "0.5.2"}
+  "ocamlformat" {dev & >= "0.9"}
   # FIXME: uncomment dune when set up
   # "dune" {build}
-]
-depopts: [
-  "ocamlformat" {>= "0.9"}
-]
-
-conflicts: [
-  "ocamlformat" {< "0.9"}
 ]
 
 build: [


### PR DESCRIPTION
This is initial `efftester.opam` file that I wrote. The file successfully passed the `opam lint` command. 

I picked version of OCaml that Efftester was initially developed and tested on. The same is with QCheck. 

I added `ocamlformat` as an optional dependency, as it is needed only for development of Efftester not consumption. 

I added commands for dune when we add it as our build system for the project.
