### PR TITLE
Add Travis CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 _build/
 _opam/
-generated_tests/
 */.merlin
 *.byte
 *.native

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 _build/
 _opam/
-testdir/*
+generated_tests/
 */.merlin
 *.byte
 *.native

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ testdir/*
 */.merlin
 *.byte
 *.native
+*.out

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: c
+sudo: false
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
+script: bash -ex .travis-opam.sh
+env:
+  - OCAML_VERSION=4.07
+os:
+  - linux

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
+.PHONY: build
 build:
-	dune build src/effmain.exe
+	mkdir generated_tests && dune build src/effmain.exe
 
+.PHONY: exec
 exec:
 	dune exec src/effmain.exe
 
+.PHONY: tests
 tests:
 	dune build src/ci_tests.exe && dune exec src/ci_tests.exe
 
+.PHONY: clean
 clean:
 	dune clean
-	rm -f testdir/test.{ml,o,cmi,cmo,cmx} testdir/{byte,native,byte.out,native.out}
+	rm -f -r generated_tests
 
+.PHONY: clean
 format:
 	dune build @fmt --auto-promote

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build
 build:
-	mkdir generated_tests && dune build src/effmain.exe
+	dune build src/effmain.exe
 
 .PHONY: exec
 exec:
@@ -13,7 +13,7 @@ tests:
 .PHONY: clean
 clean:
 	dune clean
-	rm -f -r generated_tests
+	rm -f generated_tests/*
 
 .PHONY: clean
 format:

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ build:
 exec:
 	dune exec src/effmain.exe
 
+tests:
+	dune build src/ci_tests.exe && dune exec src/ci_tests.exe
+
 clean:
 	dune clean
 	rm -f testdir/test.{ml,o,cmi,cmo,cmx} testdir/{byte,native,byte.out,native.out}

--- a/efftester.opam
+++ b/efftester.opam
@@ -23,13 +23,12 @@ depends: [
   "ocaml" {>= "4.04.0"}
   "qcheck" {>= "0.5.2"}
   "ocamlformat" {dev & >= "0.9"}
-  # FIXME: uncomment dune when set up
-  # "dune" {build}
+  "dune" {build}
 ]
 
 build: [
-    [make "eff"]
-  # ["dune" "build" "-p" name "-j" jobs]
+    [make "build"]
+    [make "tests"] {with-test}
 ]
 
 description: ""

--- a/generated_tests/.gitignore
+++ b/generated_tests/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/ci_tests.ml
+++ b/src/ci_tests.ml
@@ -1,0 +1,9 @@
+open Efftester
+
+let () =
+  resetvar ();
+  resettypevar ();
+  QCheck_runner.run_tests_main
+    (* [ unify_funtest; gen_classify; ocaml_test; tcheck_test; rand_eq_test ] *)
+    [ ocaml_test; tcheck_test ]
+;;

--- a/src/dune
+++ b/src/dune
@@ -1,3 +1,4 @@
 (executables
- (names effmain effstat)
- (libraries qcheck))
+ (names effmain effstat ci_tests)
+ (libraries qcheck)
+)

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -16,7 +16,7 @@ let write_prog src filename =
 ;;
 
 let run srcfile compil_filename compil_comm =
-  let exefile = "testdir/" ^ compil_filename in
+  let exefile = "generated_tests/" ^ compil_filename in
   let exitcode = Sys.command (compil_comm ^ " " ^ srcfile ^ " -o " ^ exefile) in
   (* Check that compilation was successful *)
   if exitcode <> 0
@@ -31,7 +31,7 @@ let run srcfile compil_filename compil_comm =
 
 let nativeByteEquivalence (*printFunction*) src =
   (* Write OCaml source to file *)
-  let file = "testdir/test.ml" in
+  let file = "generated_tests/test.ml" in
   let () = write_prog src file in
   let ncode, nout = run file "native" "ocamlopt -O3 -w -5-26" in
   (* -w -5@20-26 *)
@@ -1509,7 +1509,7 @@ let ocaml_test =
              print_string ".";
              flush stdout
            in
-           let file = "testdir/ocamltest.ml" in
+           let file = "generated_tests/ocamltest.ml" in
            let () = write_prog (toOCaml t) file in
            0 = Sys.command ("ocamlc -w -5@20-26 " ^ file)
          with Failure _ -> false))


### PR DESCRIPTION
Added Travis CI support based on [ocaml-ci-scripts repo](https://github.com/ocaml/ocaml-ci-scripts). Solves #5 

1) Even with push rights, it seems like I cannot add Travis CI support to this repo: I have neither Settings tab on the repo nor this repo in my travis account on the [travis website](https://travis-ci.org). 

2) I tested the build on my own repo, the _setup part goes well_, but `make tests` fails with the error below: 
```
# === Error ======================================================================
# 
# Test generated term passes OCaml's typecheck errored on (3 shrink steps):
# 
# Some (0)
# 
# exception Sys_error("testdir/ocamltest.ml: No such file or directory")
# 
# ================================================================================
# failure (0 tests failed, 1 tests errored, ran 2 tests)
# make: *** [tests] Error 1
```
Running the same command on my machine does not produce this error. For some reason, `ocamltest.ml` file is missing.

3) Also to note, the build times are quite large:
 ~15 min for linux
 ~20 min for macos