### PR TITLE
Add better float generator

### DIFF
--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -173,7 +173,7 @@ let efftostr ((ef, ev) : eff) = Printf.sprintf "(%B,%B)" ef ev
 let toOCaml ?(typeannot = true) term =
   let rec littoOcamlSB sb = function
     | LitUnit -> Printf.bprintf sb "()"
-    | LitInt i -> if i <= 0 then Printf.bprintf sb "(%d)" i else Printf.bprintf sb "%d" i
+    | LitInt i -> if i < 0 then Printf.bprintf sb "(%d)" i else Printf.bprintf sb "%d" i
     | LitFloat f ->
       if f <= 0. then Printf.bprintf sb "(%F)" f else Printf.bprintf sb "%F" f
     (* We want parentheses when f equals (-0.);


### PR DESCRIPTION
- Replaced the QCheck standard float generator with a more compiler testing-oriented one, which generates corner cases more often
- Refactored integer generator: we do not to use `'a arbitrary`, as we can directly build a `Gen.t` generator. 

TODO: 
1. Pick a good ratio of corner cases to random floats. We can decide this together.
2. Implement the idea of Jan's reviewer: 

> a folklore approach to generate arbitrary integers (suggested to me by a reviewer) is to first generate an arbitrary list of numbers, and then later with, say 50% chance choose from this list, or with 50% chance generate a "fresh" random number. Such a generator will have a reasonable chance of outputting duplicate numbers (a common boundary case).