### PR TITLE
Add ref support

### DIFF
--- a/src/effast.ml
+++ b/src/effast.ml
@@ -66,8 +66,6 @@ and pattern =
   | PattVar of variable
   | PattConstr of etype * string * pattern list
 
-let some typ payload eff = Constructor (typ, "Some", [ payload ], eff)
-let none typ = Constructor (typ, "None", [], (false, false))
 let no_eff = (false, false)
 let eff_join (ef, ev) (ef', ev') = (ef || ef', ev || ev')
 
@@ -154,3 +152,6 @@ let rec normalize_eff t =
     List t''
   | Fun (s, _, t) -> Fun (normalize_eff s, no_eff, normalize_eff t)
 ;;
+
+let some typ payload eff = Constructor (typ, "Some", [ payload ], eff)
+let none typ = Constructor (typ, "None", [], (false, false))

--- a/src/effast.ml
+++ b/src/effast.ml
@@ -155,3 +155,26 @@ let rec normalize_eff t =
 
 let some typ payload eff = Constructor (typ, "Some", [ payload ], eff)
 let none typ = Constructor (typ, "None", [], (false, false))
+
+module Ref = struct
+  let ref_t =
+    let new_tv = newtypevar () in
+    Fun (Typevar new_tv, (true, false), Ref (Typevar new_tv))
+  ;;
+
+  let ref_f = Variable (ref_t, "ref")
+
+  let deref_t =
+    let new_tv = newtypevar () in
+    Fun (Ref (Typevar new_tv), (false, false), Typevar new_tv)
+  ;;
+
+  let deref_f = Variable (deref_t, "(!)")
+
+  let update_t =
+    let new_tv = newtypevar () in
+    Fun (Ref (Typevar new_tv), (false, false), Fun (Typevar new_tv, (true, false), Unit))
+  ;;
+
+  let update_f = Variable (update_t, "(:=)")
+end

--- a/src/effast.ml
+++ b/src/effast.ml
@@ -58,6 +58,7 @@ type term =
   (* [PatternMatch typ matched_trm cases eff] *)
   | PatternMatch of etype * term * (pattern * term) list * eff
   | Lambda of etype * variable * etype * term
+  (* [App (return_type, fn, arg_type, arg, eff)] *)
   | App of etype * term * etype * term * eff
   | Let of variable * etype * term * term * etype * eff
   | If of etype * term * term * term * eff

--- a/src/effast.ml
+++ b/src/effast.ml
@@ -167,7 +167,7 @@ module Ref = struct
 
   let deref_t =
     let new_tv = newtypevar () in
-    Fun (Ref (Typevar new_tv), (false, false), Typevar new_tv)
+    Fun (Ref (Typevar new_tv), (true, false), Typevar new_tv)
   ;;
 
   let deref_f = Variable (deref_t, "(!)")

--- a/src/effast.ml
+++ b/src/effast.ml
@@ -78,6 +78,7 @@ let eff_leq eff eff_exp =
   | _, _ -> false
 ;;
 
+(** checks if given type variable (represented as int) occurs in given type expression *)
 let rec occurs tvar = function
   | Typevar a -> tvar = a
   | Option a -> occurs tvar a
@@ -92,13 +93,15 @@ let rec arity = function
   | _ -> 0
 ;;
 
-let rec subst repl t =
+(** [subst repl t] substitutes all type variables in [t] with mapping from type variables
+    to types given in [repl] *)
+let rec subst replacements t =
   match t with
   | Unit | Int | Float | Bool | String -> t
-  | Typevar a -> (try List.assoc a repl with Not_found -> t)
-  | Option e -> Option (subst repl e)
-  | List u -> List (subst repl u)
-  | Fun (l, e, r) -> Fun (subst repl l, e, subst repl r)
+  | Typevar i -> (try List.assoc i replacements with Not_found -> t)
+  | Option t' -> Option (subst replacements t')
+  | List t' -> List (subst replacements t')
+  | Fun (l, e, r) -> Fun (subst replacements l, e, subst replacements r)
 ;;
 
 let imm_type t =

--- a/src/effcheck.ml
+++ b/src/effcheck.ml
@@ -50,7 +50,7 @@ let check_opt_invariants (typ, name, payload_lst) =
     | "Some" ->
       (match payload_lst with
       | [ payload ] ->
-        if t = imm_type payload
+        if types_compat (imm_type payload) t
         then Ok typ
         else Error "check_opt_invariants: some payload type invariant failed"
       | _ -> Error "check_opt_invariants: some payload arity failed")

--- a/src/effenv.ml
+++ b/src/effenv.ml
@@ -130,7 +130,11 @@ let init_tri_env =
   List.fold_left
     (fun acc (var, t) -> add_var var t acc)
     (VarMap.empty, TypeMap.empty, TypeMap.empty)
-    [ (* These follow the order and specification of the Pervasives module
+    [ (* ref operators *)
+      ("ref", Ref.ref_t);
+      ("(!)", Ref.deref_t);
+      ("(:=)", Ref.update_t);
+      (* These follow the order and specification of the Pervasives module
          	  https://caml.inria.fr/pub/docs/manual-ocaml/libref/Pervasives.html *)
       (* Comparisons *)
       ( "(=)",

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -567,7 +567,7 @@ module GeneratorsWithContext (Ctx : Context) = struct
     in
     [ (3, gen) ]
 
-  and list_intro_rules env goal_typ eff size : (int * term option Gen.t) list =
+  and list_intro_rules env goal_typ eff size =
     let open Syntax in
     match goal_typ with
     | List elt_typ ->

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -194,16 +194,18 @@ module GeneratorsWithContext (Ctx : Context) = struct
 
   (* Type-directed literal generator *)
   let literal_gen t _eff _size =
+    let fail s = Printf.sprintf "literal_gen: %s arg. should not happen" s |> failwith in
     match t with
     | Unit -> Gen.return LitUnit
     | Int -> Gen.map (fun i -> LitInt i) int_gen
     | Float -> Gen.map (fun f -> LitFloat f) float_gen
     | Bool -> Gen.map (fun b -> LitBool b) Gen.bool
     | String -> Gen.map (fun s -> LitStr s) string_gen
-    | Option _ -> failwith "literal_gen: option arg. should not happen"
-    | List _ -> failwith "literal_gen: list arg. should not happen"
-    | Typevar _ -> failwith "literal_gen: typevar arg. should not happen"
-    | Fun _ -> failwith "literal_gen: funtype arg. should not happen"
+    | Option _ -> fail "option"
+    | Ref _ -> fail "ref"
+    | List _ -> fail "list"
+    | Typevar _ -> fail "typevar"
+    | Fun _ -> fail "funtype"
   ;;
 
   (* Sized generator of variables according to the LIT rule

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -167,7 +167,7 @@ module StaticGenerators = struct
           Gen.frequency
             [ (* Generate no alphas *)
               (4, Gen.oneofl base_types);
-              (1, Gen.map (fun t -> List t) (recgen (n / 2)));
+              (1, Gen.map (fun t -> List t) (recgen (sqrt n)));
               ( 1,
                 Gen.map3
                   (fun t e t' -> Fun (t, e, t'))

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -227,7 +227,7 @@ module GeneratorsWithContext (Ctx : Context) = struct
     | List s when list_of_fun s -> []
     | Unit | Int | Float | Bool | String ->
       [ (6, Gen.map (fun l -> Some (Lit l)) (literal_gen s eff size)) ]
-    | List _ | Option _ | Fun _ | Typevar _ -> []
+    | List _ | Option _ | Ref _ | Fun _ | Typevar _ -> []
   ;;
 
   (* Sized generator of variables according to the VAR rule
@@ -276,7 +276,7 @@ module GeneratorsWithContext (Ctx : Context) = struct
       return_opt (Lambda (Fun (s, myeff, imm_type m), x, s, m))
     in
     match u with
-    | Unit | Int | Float | Bool | String | Option _ | List _ | Typevar _ -> []
+    | Unit | Int | Float | Bool | String | Option _ | Ref _ | List _ | Typevar _ -> []
     | Fun (s, e, t) -> [ (8, gen s e t) ]
 
   (* Sized generator of applications (calls) according to the APP rule

--- a/src/effprint.ml
+++ b/src/effprint.ml
@@ -45,6 +45,7 @@ let pp_type ?(effannot = false) ppf etype =
     let below = pp_simple_type in
     let rec self ppf = function
       | Option e -> Format.fprintf ppf "%a@ option" self e
+      | Ref e -> Format.fprintf ppf "%a@ ref" self e
       | List s -> Format.fprintf ppf "%a@ list" self s
       | other -> below ppf other
     in
@@ -56,7 +57,7 @@ let pp_type ?(effannot = false) ppf etype =
     | Float -> Format.fprintf ppf "float"
     | Bool -> Format.fprintf ppf "bool"
     | String -> Format.fprintf ppf "string"
-    | (Fun _ | Option _ | List _) as non_simple ->
+    | (Fun _ | Option _ | Ref _ | List _) as non_simple ->
       Format.fprintf ppf "@[<2>(%a)@]" pp_type non_simple
   in
   pp_type ppf etype

--- a/src/effshrink.ml
+++ b/src/effshrink.ml
@@ -106,6 +106,7 @@ let rec minimal_term ty =
   | Bool -> Lit (LitBool true)
   | String -> Lit (LitStr "")
   | Option _ -> Constructor (ty, "None", [], no_eff)
+  | Ref t -> App (ty, Ref.ref_f, t, minimal_term t, (true, false))
   | List _ -> ListTrm (ty, [], no_eff)
   | Fun (input_t, _, output_t) ->
     let body = minimal_term output_t in

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -78,7 +78,7 @@ let printer_by_etype typ =
     | Int -> ("print_int", lookup_var "print_int" init_tri_env)
     | Float -> ("print_float", lookup_var "print_float" init_tri_env)
     | String -> ("print_string", lookup_var "print_string" init_tri_env)
-    | Unit | Typevar _ | Option _ | List _ | Fun _ | Bool ->
+    | Unit | Typevar _ | Option _ | Ref _ | List _ | Fun _ | Bool ->
       failwith
         "printer_by_etype: such base type should not be generated (not implemented)"
   in

--- a/src/effunif.ml
+++ b/src/effunif.ml
@@ -17,6 +17,7 @@ let rec unify_list = function
     | Bool, Bool -> sub
     | String, String -> sub
     | Option a, Option b -> unify_list [ (a, b) ] @ sub
+    | Ref a, Ref b -> unify_list [ (a, b) ] @ sub
     | Typevar a, Typevar b -> if a = b then sub else (a, r) :: sub
     | List a, List b ->
       let sub' = unify_list [ (a, b) ] in
@@ -32,6 +33,7 @@ let rec unify_list = function
     | Bool, _
     | String, _
     | Option _, _
+    | Ref _, _
     | List _, _
     | Fun _, _ ->
       raise No_solution)
@@ -55,6 +57,8 @@ let rec types_compat t t' =
   | String, _ -> false
   | Option a, Option b -> types_compat a b
   | Option _, _ -> false
+  | Ref a, Ref b -> types_compat a b
+  | Ref _, _ -> false
   | Fun (at, e, rt), Fun (at', e', rt') ->
     types_compat at' at && types_compat rt rt' && eff_leq e e'
   | Fun _, _ -> false


### PR DESCRIPTION
This PR adds `'a ref` type support to Efftester generator. 

`ref`s do not require new grammar constructs but addition of variant `Ref of etype` to `etype` and of three functions to the initial environment: `ref`, `(!)`, and `(:=)`. 

This PR will: 
- [x] add `Ref` variant to `etype` and fix inexhaustive pattern matches that result;
- [x] add three operations (functions) that create, dereference, and update refs;
- [x] fix minor problems with formatting, commenting along the way