### PR TITLE
Implement type-checking of patterns

### DIFF
--- a/src/effast.ml
+++ b/src/effast.ml
@@ -121,7 +121,7 @@ type constr_descr =
 
 (** type [pattern] is used to represent patterns in OCaml *)
 type pattern =
-  | PattVar of variable
+  | PattVar of etype * variable
   | PattConstr of etype * constr_descr * pattern list
 
 (** type [term] is used to represent terms of OCaml available Efftester *)
@@ -163,7 +163,7 @@ let imm_type t =
 ;;
 
 let imm_pat_type = function
-  | PattVar _ -> Typevar (newtypevar ())
+  | PattVar (t, _) -> t
   | PattConstr (t, _, _) -> t
 ;;
 

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -103,6 +103,7 @@ module Syntax = struct
   let fail = GenOpt.fail
   let ( >>= ) = Gen.( >>= )
   let ( >>=? ) = GenOpt.( >>= )
+  let ( >|= ) = Gen.( >|= )
 end
 
 (** Generators *)
@@ -124,6 +125,19 @@ module StaticGenerators = struct
   ;;
 
   let var_gen = Gen.map (String.make 1) alpha_gen
+
+  let fresh_var_gen domain =
+    let is_fresh x = not (VarSet.mem x domain) in
+    let open Syntax in
+    var_gen >|= fun var ->
+    if is_fresh var then var
+    else
+      let rec loop i =
+        let var' = Printf.sprintf "%s_%d" var i in
+        if is_fresh var' then var'
+        else loop (i + 1)
+      in loop 1
+
   let string_gen = Gen.small_string ~gen:alpha_gen
   let str_to_str = Printf.sprintf "%S"
   let sqrt i = int_of_float (Pervasives.sqrt (float_of_int i))
@@ -233,19 +247,23 @@ module StaticGenerators = struct
   (* a function that generates a pattern directed by the given type:
      tuples are mapped into tuples, all other types are mapped into variables *)
   let pattern_of_type env typ st =
-    (* keep track of variables using [env] because var names in a pattern must be unique *)
+    let fresh_pat_var =
+      (* keep track of already-generated variables
+         because var names in a pattern must be unique *)
+      let pat_vars = ref VarSet.empty in
+      fun () ->
+        let pat_var = fresh_var_gen !pat_vars st in
+        pat_vars := VarSet.add pat_var !pat_vars;
+        pat_var in
     let env = ref env in
     let rec to_pat = function
       | Tuple elt_types ->
         let arity = List.length elt_types in
         PattConstr (typ, TupleArity arity, List.map to_pat elt_types)
       | other ->
-        let var = var_gen st in
-        (match lookup_var var !env with
-        | Some _ -> to_pat other
-        | None ->
-          env := add_var var typ !env;
-          PattVar (other, var))
+        let var = fresh_pat_var () in
+        env := add_var var other !env;
+        PattVar (other, var)
     in
     let pat = to_pat typ in
     (pat, !env)

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -245,7 +245,7 @@ module StaticGenerators = struct
         | Some _ -> to_pat other
         | None ->
           env := add_var var typ !env;
-          PattVar var)
+          PattVar (other, var))
     in
     (to_pat typ, !env)
   ;;
@@ -630,8 +630,10 @@ module GeneratorsWithContext (Ctx : Context) = struct
         (PatternMatch
            ( t,
              match_trm,
-             [ (PattConstr (bt, Variant "Some", [ PattVar var_name ]), some_branch_trm);
-               (PattConstr (bt, Variant "None", []), none_branch_trm)
+             [ (PattConstr (bt, Variant "Some", [ PattVar (bt, var_name) ]),
+                some_branch_trm);
+               (PattConstr (bt, Variant "None", []),
+                none_branch_trm)
              ],
              eff ))
     in

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -247,7 +247,8 @@ module StaticGenerators = struct
           env := add_var var typ !env;
           PattVar (other, var))
     in
-    (to_pat typ, !env)
+    let pat = to_pat typ in
+    (pat, !env)
   ;;
 end
 

--- a/src/effprint.ml
+++ b/src/effprint.ml
@@ -114,7 +114,7 @@ let pp_pattern ppf pat =
         patt_lst
     | PattVar _ as simple -> pp_simple_pattern ppf simple
   and pp_simple_pattern ppf = function
-    | PattVar v -> pp_var ppf v
+    | PattVar (_typ, v) -> pp_var ppf v
     | non_simple -> Format.fprintf ppf "(%a)" pp_pattern non_simple
   in
   pp_pattern ppf pat

--- a/src/effshrink.ml
+++ b/src/effshrink.ml
@@ -18,7 +18,7 @@ let shrink_list_elems shrink l yield =
 
 let rec occurs_in_pat var pat =
   match pat with
-  | PattVar x -> x = var
+  | PattVar (_, x) -> x = var
   | PattConstr (_, _, lst) -> List.exists (fun pt -> occurs_in_pat var pt) lst
 ;;
 

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -187,7 +187,17 @@ let can_compile_test ~with_logging =
         false
       | Some (_typ, trm) ->
         (try
-           let generated_prgm = str_of_pp (pp_term ~typeannot:false) trm in
+           (* passing ~typeannot:true here is necessary to silence
+              warning 20 (this argument will never be used by the function)
+              for code such as
+
+                match List.hd with
+                | None -> ()
+                | Some (x : unit -> unit) -> x ()
+
+              without the type annotation on the binding occurrence of x,
+              the warning would be emitted. *)
+           let generated_prgm = str_of_pp (pp_term ~typeannot:true) trm in
            logger "%s" generated_prgm;
            write_prog generated_prgm prgm_filename;
            0 = Sys.command ("ocamlc -w -5@20-26 " ^ prgm_filename)

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -129,7 +129,7 @@ module Arbitrary = struct
   let arb_dep_term_with_cache =
     make
       ~print:
-        (let printer (_typ, trm) = str_of_pp (pp_term ~typeannot:false) trm in
+        (let printer (_typ, trm) = str_of_pp (pp_term ~typeannot:true) trm in
          Print.option printer)
       ~shrink:Effshrink.wrapped_dep_term_shrinker
       (fun rs ->
@@ -187,7 +187,7 @@ let can_compile_test ~with_logging =
         false
       | Some (_typ, trm) ->
         (try
-           let generated_prgm = str_of_pp pp_term trm in
+           let generated_prgm = str_of_pp (pp_term ~typeannot:false) trm in
            logger "%s" generated_prgm;
            write_prog generated_prgm prgm_filename;
            0 = Sys.command ("ocamlc -w -5@20-26 " ^ prgm_filename)
@@ -223,7 +223,9 @@ let int_eq_test =
       ==>
       match topt with
       | None -> false
-      | Some t -> is_native_byte_equiv (str_of_pp pp_term (print_wrap t)))
+      | Some t ->
+         is_native_byte_equiv
+           (str_of_pp (pp_term ~typeannot:false) (print_wrap t)))
 ;;
 
 let rand_eq_test typ =
@@ -237,7 +239,9 @@ let rand_eq_test typ =
       ==>
       match topt with
       | None -> false
-      | Some t -> is_native_byte_equiv (str_of_pp pp_term (rand_print_wrap typ t)))
+      | Some t ->
+         is_native_byte_equiv
+           (str_of_pp (pp_term ~typeannot:false) (rand_print_wrap typ t)))
 ;;
 
 let dep_eq_test ~with_logging =
@@ -258,7 +262,9 @@ let dep_eq_test ~with_logging =
         logger "%s" "failwith(\"dep_t_opt = None\")";
         false
       | Some (typ, trm) ->
-        let generated_prgm = rand_print_wrap typ trm |> str_of_pp pp_term in
+        let generated_prgm =
+          rand_print_wrap typ trm
+          |> str_of_pp (pp_term ~typeannot:false) in
         logger "%s" generated_prgm;
         is_native_byte_equiv generated_prgm)
 ;;


### PR DESCRIPTION
When we added pattern-matching constructs, we never got around to implement `effcheck` support for them (our internal checker for well-typedness). This PR implements this check, which uncovered a couple minor bugs which are also fixed here.