### PR TITLE
Adding other int types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ sudo: false
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
-  - OCAML_VERSION=4.07
+  - OCAML_VERSION=4.08
 os:
   - linux

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: build exec run tests clean format
 
 build:
-	dune build src/effmain.exe $(dune_args)
+	dune build src/effmain.exe $(build_args)
 
 exec:
-	dune exec src/effmain.exe $(dune_args) -- -v --colors $(qcheck_args)
+	dune exec src/effmain.exe $(exec_args) -- -v --colors $(qcheck_args)
 
 run: build exec
 
-tests:
+test:
 	dune build src/ci_tests.exe $(build_args) && \
 	dune exec src/ci_tests.exe $(exec_args) -- -v --colors $(qcheck_args)
 

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,20 @@
-.PHONY: build
+.PHONY: build exec run tests clean format
+
 build:
-	dune build src/effmain.exe
+	dune build src/effmain.exe $(dune_args)
 
-.PHONY: exec
 exec:
-	dune exec src/effmain.exe -- -v --colors $(args)
+	dune exec src/effmain.exe $(dune_args) -- -v --colors $(qcheck_args)
 
-.PHONY: tests
+run: build exec
+
 tests:
-	dune build src/ci_tests.exe && dune exec src/ci_tests.exe -- -v --colors $(args)
+	dune build src/ci_tests.exe $(build_args) && \
+	dune exec src/ci_tests.exe $(exec_args) -- -v --colors $(qcheck_args)
 
-.PHONY: clean
 clean:
 	dune clean
 	rm -f generated_tests/*
 
-.PHONY: clean
 format:
 	dune build @fmt --auto-promote

--- a/dune
+++ b/dune
@@ -1,0 +1,6 @@
+(dirs :standard \ generated_tests)
+
+(env
+ (dev
+  (flags
+   (:standard -warn-error -A))))

--- a/dune
+++ b/dune
@@ -3,4 +3,4 @@
 (env
  (dev
   (flags
-   (:standard -warn-error -A))))
+   (:standard -alert --deprecated))))

--- a/efftester.opam
+++ b/efftester.opam
@@ -20,7 +20,7 @@ maintainer: [
 dev-repo: "git+https://github.com/gasche/efftester.git"
 
 depends: [
-  "ocaml" {>= "4.04.0"}
+  "ocaml" {>= "4.08.1"}
   "qcheck" {>= "0.6"}
   "ocamlformat" {dev & >= "0.9"}
   "dune" {build}

--- a/src/effcheck.ml
+++ b/src/effcheck.ml
@@ -29,6 +29,9 @@ let tcheck_lit l =
   match l with
   | LitUnit -> (Unit, no_eff)
   | LitInt _ -> (Int, no_eff)
+  | LitInt32 _ -> (Int32, no_eff)
+  | LitInt64 _ -> (Int64, no_eff)
+  | LitNativeInt _ -> (NativeInt, no_eff)
   | LitFloat _ -> (Float, no_eff)
   | LitBool _ -> (Bool, no_eff)
   | LitStr _ -> (String, no_eff)

--- a/src/effcheck.ml
+++ b/src/effcheck.ml
@@ -39,22 +39,25 @@ let tcheck_lit l =
 let rec pcheck = function
   | PattVar (ty, x) -> VarMap.singleton x ty
   | PattConstr (ty, cstr, ps) ->
-     let disjoint_union env1 env2 =
-       VarMap.merge (fun x o1 o2 ->
-           match o1, o2 with
-             | None, None -> None
-             | Some ty, None | None, Some ty -> Some ty
-             | Some _, Some _ ->
-                Test.fail_reportf
-                  "pcheck: the variable %s occurs more than once" x)
-       env1 env2 in
-     let pcheck_args tys args =
-       if List.length tys <> List.length args
-       then Test.fail_report "pcheck: arity mismatch";
-       List.fold_left2 (fun env ty p ->
-           let p_ty = imm_pat_type p in
-           if not (types_compat ty p_ty)
-           (* Note: this check is in the opposite direction
+    let disjoint_union env1 env2 =
+      VarMap.merge
+        (fun x o1 o2 ->
+          match (o1, o2) with
+          | None, None -> None
+          | Some ty, None | None, Some ty -> Some ty
+          | Some _, Some _ ->
+            Test.fail_reportf "pcheck: the variable %s occurs more than once" x)
+        env1
+        env2
+    in
+    let pcheck_args tys args =
+      if List.length tys <> List.length args
+      then Test.fail_report "pcheck: arity mismatch";
+      List.fold_left2
+        (fun env ty p ->
+          let p_ty = imm_pat_type p in
+          if not (types_compat ty p_ty)
+             (* Note: this check is in the opposite direction
               than the check on terms: in a constructedterm
               `K(e)`, the immediate type of `e` may be "less"
               (less effectful, less general) than the type expected by K;
@@ -70,35 +73,32 @@ let rec pcheck = function
               On the other hand, it would be unsound for (x, y) to claim to match
               on ((a -{impure}-> b) * c) and yet populate the environment with
               (x : (a -{pure}-> b)). *)
-           then Test.fail_report "pcheck: inner pattern mismatch";
-           disjoint_union env (pcheck p))
-         VarMap.empty tys args
-     in
-     begin match cstr, ty with
-       | TupleArity n, Tuple tys ->
-          if not (List.length tys = n)
-          then Test.fail_report "pcheck: tuple arity mismatch";
-          pcheck_args tys ps
-       | TupleArity _, _ ->
-          Test.fail_report "pcheck: tuple constructor at non-tuple type";
-       | Variant "None", Option _t ->
-          pcheck_args [] ps
-       | Variant "Some", Option t ->
-          pcheck_args [t] ps
-       | Variant (("Some" | "None") as cstr), _ ->
-          Test.fail_reportf "pcheck: %s must have type option" cstr
-       | Variant cstr, _ ->
-          Test.fail_reportf "pcheck: unknown variant constructor %S" cstr
-     end
+          then Test.fail_report "pcheck: inner pattern mismatch";
+          disjoint_union env (pcheck p))
+        VarMap.empty
+        tys
+        args
+    in
+    (match (cstr, ty) with
+    | TupleArity n, Tuple tys ->
+      if not (List.length tys = n) then Test.fail_report "pcheck: tuple arity mismatch";
+      pcheck_args tys ps
+    | TupleArity _, _ -> Test.fail_report "pcheck: tuple constructor at non-tuple type"
+    | Variant "None", Option _t -> pcheck_args [] ps
+    | Variant "Some", Option t -> pcheck_args [ t ] ps
+    | Variant (("Some" | "None") as cstr), _ ->
+      Test.fail_reportf "pcheck: %s must have type option" cstr
+    | Variant cstr, _ -> Test.fail_reportf "pcheck: unknown variant constructor %S" cstr)
+;;
 
 (** checks that given term has indicated type and holds invariants associated with it *)
-let compat_sig (ty1, eff1) (ty2, eff2) =
-  types_compat ty1 ty2 && eff_leq eff1 eff2
+let compat_sig (ty1, eff1) (ty2, eff2) = types_compat ty1 ty2 && eff_leq eff1 eff2
 
 let assert_compat explanation sig1 sig2 =
   if compat_sig sig1 sig2
   then ()
   else Test.fail_reportf "effcheck: signature mismatch in %s" explanation
+;;
 
 let rec tcheck_compat env term explanation expected_sig =
   let term_sig = tcheck env term in
@@ -108,54 +108,44 @@ and tcheck env term =
   match term with
   | Lit l -> tcheck_lit l
   | Variable (t, v) ->
-    begin match VarMap.find v env with
-      | exception Not_found ->
-         Test.fail_reportf "tcheck: unknown variable %s" v
-      | et ->
-         if not (types_compat et t)
-                (* annotation may be more concrete then inferred type *)
-         then Test.fail_report "tcheck: variable types disagree";
-         (et, no_eff)
-    end
+    (match VarMap.find v env with
+    | exception Not_found -> Test.fail_reportf "tcheck: unknown variable %s" v
+    | et ->
+      if not (types_compat et t) (* annotation may be more concrete then inferred type *)
+      then Test.fail_report "tcheck: variable types disagree";
+      (et, no_eff))
   | ListTrm (typ, lst, eff) ->
-     let elem_typ = match typ with
-         | List et -> et
-         | _ -> Test.fail_report "tcheck: ListTrm must have a list type"
-     in
-     List.iter
-       (fun e -> tcheck_compat env e "list element" (elem_typ, eff))
-       lst;
-     (typ, eff)
+    let elem_typ =
+      match typ with
+      | List et -> et
+      | _ -> Test.fail_report "tcheck: ListTrm must have a list type"
+    in
+    List.iter (fun e -> tcheck_compat env e "list element" (elem_typ, eff)) lst;
+    (typ, eff)
   | Constructor (typ, cstr, args, eff) ->
-     let check_args tys args =
-       if List.length tys <> List.length args
-       then Test.fail_report "tcheck: arity mismatch";
-       List.iter2
-         (fun ty e -> tcheck_compat env e "constructor argument" (ty, eff))
-         tys args
-     in
-     begin match typ with
-       | Tuple tys ->
-          begin match cstr with
-            | TupleArity i ->
-               if List.length tys <> i then
-                 Test.fail_report "tcheck: tuple constructor of incorrect arity";
-               check_args tys args
-            | _ ->
-               Test.fail_report "tcheck: incorrect tuple constructor"
-          end
-       | Option t ->
-          begin match cstr with
-            | Variant "None" ->
-               check_args [] args
-            | Variant "Some" ->
-               check_args [t] args
-            | _ ->
-               Test.fail_report "tcheck: incorrect option constructor"
-          end
-       | _ -> Test.fail_report "tcheck: constructor at unexpected type"
-     end;
-     (typ, eff)
+    let check_args tys args =
+      if List.length tys <> List.length args
+      then Test.fail_report "tcheck: arity mismatch";
+      List.iter2
+        (fun ty e -> tcheck_compat env e "constructor argument" (ty, eff))
+        tys
+        args
+    in
+    (match typ with
+    | Tuple tys ->
+      (match cstr with
+      | TupleArity i ->
+        if List.length tys <> i
+        then Test.fail_report "tcheck: tuple constructor of incorrect arity";
+        check_args tys args
+      | _ -> Test.fail_report "tcheck: incorrect tuple constructor")
+    | Option t ->
+      (match cstr with
+      | Variant "None" -> check_args [] args
+      | Variant "Some" -> check_args [ t ] args
+      | _ -> Test.fail_report "tcheck: incorrect option constructor")
+    | _ -> Test.fail_report "tcheck: constructor at unexpected type");
+    (typ, eff)
   | PatternMatch (ret_typ, matched_trm, cases, eff) ->
     tcheck env matched_trm |> ignore;
     let check_case (pat, body) =
@@ -167,61 +157,63 @@ and tcheck env term =
   | App (rt, m, at, n, ceff) ->
     let mtyp, meff = tcheck env m in
     let ntyp, neff = tcheck env n in
-    let fun_eff = match mtyp with
-        | Fun (_, eff, _) -> eff
-        | _ ->
-           Test.fail_report "tcheck: application of non-function type"
+    let fun_eff =
+      match mtyp with
+      | Fun (_, eff, _) -> eff
+      | _ -> Test.fail_report "tcheck: application of non-function type"
     in
-    if not (List.mem no_eff [meff; neff])
+    if not (List.mem no_eff [ meff; neff ])
     then Test.fail_report "tcheck: application has subexprs with eff";
     let msub, mtyp =
       match unify mtyp (Fun (at, ceff, rt)) with
-        | No_sol ->
-           Test.fail_reportf
-             ("tcheck: function types do not unify in application:@;"
-              ^^ "@[<v>mtyp is %a,@ (Fun (at,ceff,rt)) is %a@]")
-             (pp_type ~effannot:true)
-             mtyp
-             (pp_type ~effannot:true)
-             (Fun (at, ceff, rt))
-        | Sol sub ->
-           sub, subst sub mtyp in
+      | No_sol ->
+        Test.fail_reportf
+          ("tcheck: function types do not unify in application:@;"
+          ^^ "@[<v>mtyp is %a,@ (Fun (at,ceff,rt)) is %a@]")
+          (pp_type ~effannot:true)
+          mtyp
+          (pp_type ~effannot:true)
+          (Fun (at, ceff, rt))
+      | Sol sub -> (sub, subst sub mtyp)
+    in
     let _nsub, ntyp =
       match unify ntyp at with
-        | No_sol ->
-           Test.fail_reportf
-             ("tcheck: argument types do not unify in application:@;"
-              ^^ "@[<v>ntyp is %a,@ at is %a@]")
-             (pp_type ~effannot:true)
-             ntyp
-             (pp_type ~effannot:true)
-             at
-        | Sol sub ->
-           sub, subst sub ntyp
+      | No_sol ->
+        Test.fail_reportf
+          ("tcheck: argument types do not unify in application:@;"
+          ^^ "@[<v>ntyp is %a,@ at is %a@]")
+          (pp_type ~effannot:true)
+          ntyp
+          (pp_type ~effannot:true)
+          at
+      | Sol sub -> (sub, subst sub ntyp)
     in
-    if not (types_compat mtyp (Fun (at, ceff, rt))) then
+    if not (types_compat mtyp (Fun (at, ceff, rt)))
+    then
       Test.fail_reportf
         ("tcheck: function types disagree in application:@;"
-         ^^ "@[<v>sub is %a,@ mtyp is %a,@ (Fun (at,ceff,rt)) is %a@]")
+        ^^ "@[<v>sub is %a,@ mtyp is %a,@ (Fun (at,ceff,rt)) is %a@]")
         (pp_solution ~effannot:true)
         msub
         (pp_type ~effannot:true)
         mtyp
         (pp_type ~effannot:true)
         (Fun (at, ceff, rt));
-    if not (types_compat ntyp at) then
+    if not (types_compat ntyp at)
+    then
       Test.fail_reportf
         ("tcheck: argument types disagree in application:@;"
-         ^^ "@[<v>ntyp is %a,@ at is %a@]")
+        ^^ "@[<v>ntyp is %a,@ at is %a@]")
         (pp_type ~effannot:true)
         ntyp
         (pp_type ~effannot:true)
         at;
     let j_eff = eff_join fun_eff (eff_join meff neff) in
-    if not (eff_leq j_eff ceff) then
+    if not (eff_leq j_eff ceff)
+    then
       Test.fail_reportf
         ("tcheck: effect annotation disagree in application:@;"
-         ^^ "@[<v>ceff is %a,@ j_eff is %a@]")
+        ^^ "@[<v>ceff is %a,@ j_eff is %a@]")
         pp_eff
         ceff
         pp_eff
@@ -230,10 +222,11 @@ and tcheck env term =
   | Let (x, t, m, n, ltyp, leff) ->
     let mtyp, meff = tcheck env m in
     let ntyp, neff = tcheck (VarMap.add x mtyp env) n in
-    if not (types_compat mtyp t) then
-      Test.fail_report "tcheck: let-bound type disagrees with annotation";
+    if not (types_compat mtyp t)
+    then Test.fail_report "tcheck: let-bound type disagrees with annotation";
     (*  annot "int list" instead of the more general "'a list" *)
-    if not (types_compat ntyp ltyp) then
+    if not (types_compat ntyp ltyp)
+    then
       Test.fail_reportf
         ("tcheck: let-body's type disagrees with annotation:@;"
         ^^ "@[<v>ntyp is %a, ltyp is %a@]")
@@ -242,7 +235,8 @@ and tcheck env term =
         (pp_type ~effannot:true)
         ltyp;
     let j_eff = eff_join meff neff in
-    if not (eff_leq j_eff leff) then
+    if not (eff_leq j_eff leff)
+    then
       Test.fail_reportf
         ("tcheck: let-effect disagrees with annotation:@;"
         ^^ "@[<v>leff is %a,@ j_eff is %a@]")
@@ -269,19 +263,19 @@ and tcheck env term =
     assert_compat "boolean condition" (btyp, beff) (Bool, e);
     let mtyp, meff = tcheck env m in
     let ntyp, neff = tcheck env n in
-    let mtyp, ntyp = match unify mtyp ntyp with
-        | No_sol ->
-           Test.fail_reportf
-             ("tcheck: If's branch types do not unify:@;"
-              ^^ "@[<v>term is %a,@ mtyp is %a,@ ntyp is %a@]")
-             (pp_term ~typeannot:false)
-             term
-             (pp_type ~effannot:true)
-             mtyp
-             (pp_type ~effannot:true)
-             ntyp
-        | Sol sub ->
-           subst sub mtyp, subst sub ntyp
+    let mtyp, ntyp =
+      match unify mtyp ntyp with
+      | No_sol ->
+        Test.fail_reportf
+          ("tcheck: If's branch types do not unify:@;"
+          ^^ "@[<v>term is %a,@ mtyp is %a,@ ntyp is %a@]")
+          (pp_term ~typeannot:false)
+          term
+          (pp_type ~effannot:true)
+          mtyp
+          (pp_type ~effannot:true)
+          ntyp
+      | Sol sub -> (subst sub mtyp, subst sub ntyp)
     in
     assert_compat "the then branch" (mtyp, meff) (t, e);
     assert_compat "the else branch" (ntyp, neff) (t, e);

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -130,13 +130,15 @@ module StaticGenerators = struct
     let is_fresh x = not (VarSet.mem x domain) in
     let open Syntax in
     var_gen >|= fun var ->
-    if is_fresh var then var
-    else
+    if is_fresh var
+    then var
+    else (
       let rec loop i =
         let var' = Printf.sprintf "%s_%d" var i in
-        if is_fresh var' then var'
-        else loop (i + 1)
-      in loop 1
+        if is_fresh var' then var' else loop (i + 1)
+      in
+      loop 1)
+  ;;
 
   let string_gen = Gen.small_string ~gen:alpha_gen
   let str_to_str = Printf.sprintf "%S"
@@ -254,7 +256,8 @@ module StaticGenerators = struct
       fun () ->
         let pat_var = fresh_var_gen !pat_vars st in
         pat_vars := VarSet.add pat_var !pat_vars;
-        pat_var in
+        pat_var
+    in
     let env = ref env in
     let rec to_pat = function
       | Tuple elt_types as tuple_typ ->
@@ -651,10 +654,9 @@ module GeneratorsWithContext (Ctx : Context) = struct
         (PatternMatch
            ( t,
              match_trm,
-             [ (PattConstr (ot, Variant "Some", [ PattVar (bt, var_name) ]),
-                some_branch_trm);
-               (PattConstr (ot, Variant "None", []),
-                none_branch_trm)
+             [ ( PattConstr (ot, Variant "Some", [ PattVar (bt, var_name) ]),
+                 some_branch_trm );
+               (PattConstr (ot, Variant "None", []), none_branch_trm)
              ],
              eff ))
     in

--- a/src/effgen.ml
+++ b/src/effgen.ml
@@ -159,15 +159,15 @@ module StaticGenerators = struct
       frequency [ (4, ui64); (1, oneofl [ Int64.min_int; -1L; 0L; 1L; Int64.max_int ]) ])
   ;;
 
-  (* TODO: Send a PR to QCheck and replace the fn below *)
-  let nativeint st =
-    let pos_ni = Random.State.nativeint st Nativeint.max_int in
-    match Gen.oneofl [ `Pos; `Neg ] st with
-    | `Pos -> pos_ni
-    | `Neg -> Nativeint.neg pos_ni
-  ;;
-
   let nativeint_gen =
+    (* [nativeint] in the current implementation does not generate some of the nativeint
+      values. *)
+    let nativeint st =
+      let pos_ni = Random.State.nativeint st Nativeint.max_int in
+      match Gen.oneofl [ `Pos; `Neg ] st with
+      | `Pos -> pos_ni
+      | `Neg -> Nativeint.neg pos_ni
+    in
     Gen.(
       frequency
         [ (4, nativeint);
@@ -376,15 +376,15 @@ module GeneratorsWithContext (Ctx : Context) = struct
     List.map (fun var -> (1, Gen.return (Some (Variable (s, var))))) candvars'
   ;;
 
-  (* Sized generator of lambda terms according to the LAM rule
-   @param env  : surrounding environment
-   @param u    : desired goal type
-   @param eff  : desired effect
-   @param size : size parameter
+(* Sized generator of lambda terms according to the LAM rule
+  @param env  : surrounding environment
+  @param u    : desired goal type
+  @param eff  : desired effect
+  @param size : size parameter
 
-               (x:s), env |- m : t
-    -------------------------------------------- (LAM)
-       env |- (fun (x:s) -> m) : s -> t
+              (x:s), env |- m : t
+  -------------------------------------------- (LAM)
+      env |- (fun (x:s) -> m) : s -> t
 *)
   let rec lam_rules env u _eff size =
     (* lams have no immediate effect, so 'eff' param is ignored *)

--- a/src/effprint.ml
+++ b/src/effprint.ml
@@ -64,6 +64,9 @@ let pp_type ?(effannot = false) ppf etype =
     | Typevar a -> pp_tvar ppf a
     | Unit -> Format.fprintf ppf "unit"
     | Int -> Format.fprintf ppf "int"
+    | Int32 -> Format.fprintf ppf "int32"
+    | Int64 -> Format.fprintf ppf "int64"
+    | NativeInt -> Format.fprintf ppf "nativeint"
     | Float -> Format.fprintf ppf "float"
     | Bool -> Format.fprintf ppf "bool"
     | String -> Format.fprintf ppf "string"
@@ -78,6 +81,12 @@ let pp_solution ?effannot = pp_list (pp_pair pp_tvar (pp_type ?effannot))
 let pp_lit ppf = function
   | LitUnit -> Format.fprintf ppf "()"
   | LitInt i -> if i < 0 then Format.fprintf ppf "(%d)" i else Format.fprintf ppf "%d" i
+  | LitInt32 i32 ->
+    if i32 < 0l then Format.fprintf ppf "(%ldl)" i32 else Format.fprintf ppf "%ldl" i32
+  | LitInt64 i64 ->
+    if i64 < 0L then Format.fprintf ppf "(%LdL)" i64 else Format.fprintf ppf "%LdL" i64
+  | LitNativeInt ni ->
+    if ni < 0n then Format.fprintf ppf "(%ndn)" ni else Format.fprintf ppf "%ndn" ni
   | LitFloat f ->
     if f <= 0. then Format.fprintf ppf "(%F)" f else Format.fprintf ppf "%F" f
   (* We want parentheses when f equals (-0.);

--- a/src/effprint.ml
+++ b/src/effprint.ml
@@ -115,11 +115,9 @@ let pp_pattern ~typeannot ppf pat =
     | PattVar _ as simple -> pp_simple_pattern ppf simple
   and pp_simple_pattern ppf = function
     | PattVar (typ, v) ->
-       if not typeannot
-       then pp_var ppf v
-       else Format.fprintf ppf "(%a : %a)"
-              pp_var v
-              (pp_type ~effannot:false) typ
+      if not typeannot
+      then pp_var ppf v
+      else Format.fprintf ppf "(%a : %a)" pp_var v (pp_type ~effannot:false) typ
     | non_simple -> Format.fprintf ppf "(%a)" pp_pattern non_simple
   in
   pp_pattern ppf pat
@@ -175,9 +173,13 @@ let pp_term ~typeannot ppf term =
           args)
     | PatternMatch (_, match_trm, branches, _) ->
       let pp_case ppf (pattern, body) =
-        Format.fprintf ppf "@;| @[<2>%a@ ->@ %a@]"
-          (pp_pattern ~typeannot) pattern
-          pp_arg body
+        Format.fprintf
+          ppf
+          "@;| @[<2>%a@ ->@ %a@]"
+          (pp_pattern ~typeannot)
+          pattern
+          pp_arg
+          body
         (* we use pp_arg to ensure that inner 'match' expressions get parenthesized,
            to avoid incorrect-precedence cases such as
              match x with

--- a/src/effshrink.ml
+++ b/src/effshrink.ml
@@ -82,6 +82,9 @@ let rec term_size = function
     (match lit with
     | LitUnit -> 1
     | LitInt n -> 1 + abs n (* we want shrinkers that reduce n to reduce size *)
+    | LitInt32 n -> 1 + (Int32.abs n |> Int32.to_int)
+    | LitInt64 n -> 1 + (Int64.abs n |> Int64.to_int)
+    | LitNativeInt n -> 1 + (Nativeint.abs n |> Nativeint.to_int)
     | LitFloat x -> 1 + int_of_float (ceil (abs_float x))
     | LitBool _ -> 1
     | LitStr s -> 1 + String.length s)
@@ -102,6 +105,9 @@ let rec minimal_term ty =
   | Typevar _ -> raise Not_found
   | Unit -> Lit LitUnit
   | Int -> Lit (LitInt 0)
+  | Int32 -> Lit (LitInt32 0l)
+  | Int64 -> Lit (LitInt64 0L)
+  | NativeInt -> Lit (LitNativeInt 0n)
   | Float -> Lit (LitFloat 0.)
   | Bool -> Lit (LitBool true)
   | String -> Lit (LitStr "")

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -78,7 +78,17 @@ let printer_by_etype typ =
     | Int -> ("print_int", lookup_var "print_int" init_tri_env)
     | Float -> ("print_float", lookup_var "print_float" init_tri_env)
     | String -> ("print_string", lookup_var "print_string" init_tri_env)
-    | Unit | Typevar _ | Option _ | Ref _ | Tuple _ | List _ | Fun _ | Bool ->
+    | Unit
+    | Int32
+    | Int64
+    | NativeInt
+    | Typevar _
+    | Option _
+    | Ref _
+    | Tuple _
+    | List _
+    | Fun _
+    | Bool ->
       failwith
         "printer_by_etype: such base type should not be generated (not implemented)"
   in

--- a/src/efftester.ml
+++ b/src/efftester.ml
@@ -234,8 +234,7 @@ let int_eq_test =
       match topt with
       | None -> false
       | Some t ->
-         is_native_byte_equiv
-           (str_of_pp (pp_term ~typeannot:false) (print_wrap t)))
+        is_native_byte_equiv (str_of_pp (pp_term ~typeannot:false) (print_wrap t)))
 ;;
 
 let rand_eq_test typ =
@@ -250,8 +249,8 @@ let rand_eq_test typ =
       match topt with
       | None -> false
       | Some t ->
-         is_native_byte_equiv
-           (str_of_pp (pp_term ~typeannot:false) (rand_print_wrap typ t)))
+        is_native_byte_equiv
+          (str_of_pp (pp_term ~typeannot:false) (rand_print_wrap typ t)))
 ;;
 
 let dep_eq_test ~with_logging =
@@ -273,8 +272,8 @@ let dep_eq_test ~with_logging =
         false
       | Some (typ, trm) ->
         let generated_prgm =
-          rand_print_wrap typ trm
-          |> str_of_pp (pp_term ~typeannot:false) in
+          rand_print_wrap typ trm |> str_of_pp (pp_term ~typeannot:false)
+        in
         logger "%s" generated_prgm;
         is_native_byte_equiv generated_prgm)
 ;;

--- a/src/effunif.ml
+++ b/src/effunif.ml
@@ -11,7 +11,14 @@ let rec unify_list = function
   | (l, r) :: rest ->
     let sub = unify_list rest in
     (match (subst sub l, subst sub r) with
-    | Unit, Unit | Int, Int | Float, Float | Bool, Bool | String, String -> sub
+    | Unit, Unit
+    | Int, Int
+    | Int32, Int32
+    | Int64, Int64
+    | NativeInt, NativeInt
+    | Float, Float
+    | Bool, Bool
+    | String, String -> sub
     | Option a, Option b -> unify_list [ (a, b) ] @ sub
     | Ref a, Ref b -> unify_list [ (a, b) ] @ sub
     | Typevar a, Typevar b -> if a = b then sub else (a, r) :: sub
@@ -26,6 +33,9 @@ let rec unify_list = function
     | _, Typevar a -> if occurs a l then raise No_solution else (a, l) :: sub
     | Unit, _
     | Int, _
+    | Int32, _
+    | Int64, _
+    | NativeInt, _
     | Float, _
     | Bool, _
     | String, _
@@ -33,8 +43,7 @@ let rec unify_list = function
     | Ref _, _
     | Tuple _, _
     | List _, _
-    | Fun _, _ ->
-      raise No_solution)
+    | Fun _, _ -> raise No_solution)
 ;;
 
 let unify r t = try Sol (unify_list [ (r, t) ]) with No_solution -> No_sol
@@ -43,7 +52,14 @@ let unify r t = try Sol (unify_list [ (r, t) ]) with No_solution -> No_sol
 (* or framed differently: whether the second is a particular instance of the first *)
 let rec types_compat t t' =
   match (t, t') with
-  | Unit, Unit | Int, Int | Float, Float | Bool, Bool | String, String -> true
+  | Unit, Unit
+  | Int, Int
+  | Int32, Int32
+  | Int64, Int64
+  | NativeInt, NativeInt
+  | Float, Float
+  | Bool, Bool
+  | String, String -> true
   | Option a, Option b -> types_compat a b
   | Ref a, Ref b -> types_compat a b
   | Tuple t_lst1, Tuple t_lst2 ->
@@ -57,6 +73,9 @@ let rec types_compat t t' =
     | Sol _ -> true)
   | Unit, _
   | Int, _
+  | Int32, _
+  | Int64, _
+  | NativeInt, _
   | Float, _
   | Bool, _
   | String, _
@@ -64,8 +83,7 @@ let rec types_compat t t' =
   | Ref _, _
   | Tuple _, _
   | List _, _
-  | Fun _, _ ->
-    false
+  | Fun _, _ -> false
 ;;
 
 let rec get_return_types = function


### PR DESCRIPTION
Added support for `int32`, `int64`, and `nativeint` types. 

TODO: 
[x] add type and term support for those types
[x] eliminate inexhaustive pat matches (in all src files)  
[ ] add support for functions from modules `Int32`, `Int64`, and `Nativeint`